### PR TITLE
Arrayqueue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,20 @@ default = ["termcolor"]
 log = { version = "0.4.*", features = ["std"] }
 termcolor = { version = "1.1.*", optional = true }
 chrono = "0.4.*"
+crossbeam= "0.8.0"
+
+[dev-dependencies]
+criterion = { version = "0.3", features = ["html_reports"] }
+simplelog = "0.10"
+
+[[bench]]
+name = "arrayqueue"
+harness = false
+
+[[bench]]
+name = "simple"
+harness = false
+
+[[bench]]
+name = "simplebuf"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ default = ["termcolor"]
 log = { version = "0.4.*", features = ["std"] }
 termcolor = { version = "1.1.*", optional = true }
 chrono = "0.4.*"
-crossbeam= "0.8.0"
+crossbeam-queue= "0.3.1"
 
 [dev-dependencies]
 criterion = { version = "0.3", features = ["html_reports"] }

--- a/benches/arrayqueue.rs
+++ b/benches/arrayqueue.rs
@@ -1,0 +1,58 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use log::*;
+use baselog::*;
+use std::thread;
+use std::fs::File;
+use std::time::Instant;
+
+const NTHREADS: u32 = 4;
+
+// Generates log messages
+fn log(iter: u64, thread: u32) {
+    let thread = thread.to_string();
+    for n in 0..100 {
+       info!("iter: {}, Thread: {}, item: {}", iter, thread, n); 
+    }
+
+}
+
+#[allow(unused_must_use)]
+pub fn criterion_benchmark(c: &mut Criterion) {
+    // Setup global logger
+    WriteLogger::init(LevelFilter::Info, Config::default(), File::create("log/arrayqueue.log").unwrap());
+
+    c.bench_function("arrayqueue", move |b| {
+        b.iter_custom(|iters| {
+
+            // Start the bench:
+            // Currently including the thread spawing overhead
+            // and we don't clear the logs each iter.
+            let start = Instant::now();
+
+            for i in 0..iters {
+            
+                let mut handles = vec![];
+
+                for t in 0..NTHREADS {
+                    // create the thread and generate some log entries
+                    let handle = thread::spawn(move || {
+                       black_box(log(i, t))
+                    });
+
+                    // push the handle into the vec
+                    handles.push(handle);
+                }
+
+                // join the handles in the vector
+                for i in handles {
+                    i.join().unwrap();
+                }
+            }           
+
+            start.elapsed()
+        })
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/benches/simple.rs
+++ b/benches/simple.rs
@@ -1,0 +1,58 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use log::*;
+use std::thread;
+use std::fs::File;
+use std::time::Instant;
+use simplelog::*;
+
+const NTHREADS: u32 = 4;
+
+// Generates log messages
+fn log(iter: u64, thread: u32) {
+    let thread = thread.to_string();
+    for n in 0..100 {
+       info!("iter: {}, Thread: {}, item: {}", iter, thread, n); 
+    }
+
+}
+
+#[allow(unused_must_use)]
+pub fn criterion_benchmark(c: &mut Criterion) {
+    // Setup global logger
+    WriteLogger::init(LevelFilter::Info, Config::default(), File::create("log/simple.log").unwrap());
+
+    c.bench_function("simple logger", move |b| {
+        b.iter_custom(|iters| {
+
+            // Start the bench:
+            // Currently including the thread spawing overhead
+            // and we don't clear the logs each iter.
+            let start = Instant::now();
+
+            for i in 0..iters {
+            
+                let mut handles = vec![];
+
+                for t in 0..NTHREADS {
+                    // create the thread and generate some log entries
+                    let handle = thread::spawn(move || {
+                       black_box(log(i, t))
+                    });
+
+                    // push the handle into the vec
+                    handles.push(handle);
+                }
+
+                // join the handles in the vector
+                for i in handles {
+                    i.join().unwrap();
+                }
+            }           
+
+            start.elapsed()
+        })
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/benches/simplebuf.rs
+++ b/benches/simplebuf.rs
@@ -1,0 +1,59 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use log::*;
+use std::thread;
+use std::fs::File;
+use std::time::Instant;
+use simplelog::*;
+use std::io::BufWriter;
+
+const NTHREADS: u32 = 4;
+
+// Generates log messages
+fn log(iter: u64, thread: u32) {
+    let thread = thread.to_string();
+    for n in 0..100 {
+       info!("iter: {}, Thread: {}, item: {}", iter, thread, n); 
+    }
+
+}
+
+#[allow(unused_must_use)]
+pub fn criterion_benchmark(c: &mut Criterion) {
+    // Setup global logger
+    WriteLogger::init(LevelFilter::Info, Config::default(), BufWriter::new(File::create("log/simplebuf.log").unwrap()));
+
+    c.bench_function("simple logger buf", move |b| {
+        b.iter_custom(|iters| {
+
+            // Start the bench:
+            // Currently including the thread spawing overhead
+            // and we don't clear the logs each iter.
+            let start = Instant::now();
+
+            for i in 0..iters {
+            
+                let mut handles = vec![];
+
+                for t in 0..NTHREADS {
+                    // create the thread and generate some log entries
+                    let handle = thread::spawn(move || {
+                       black_box(log(i, t))
+                    });
+
+                    // push the handle into the vec
+                    handles.push(handle);
+                }
+
+                // join the handles in the vector
+                for i in handles {
+                    i.join().unwrap();
+                }
+            }           
+
+            start.elapsed()
+        })
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/loggers/baselog.rs
+++ b/src/loggers/baselog.rs
@@ -7,7 +7,7 @@
 
 //! Module providing the SimpleLogger Implementation
 
-use super::logging::try_log;
+use super::logging::try_log_mutex;
 use crate::{Config, SharedLogger};
 use log::{
     set_boxed_logger, set_max_level, Level, LevelFilter, Log, Metadata, Record, SetLoggerError,
@@ -78,12 +78,12 @@ impl Log for SimpleLogger {
                 Level::Error => {
                     let stderr = stderr();
                     let mut stderr_lock = stderr.lock();
-                    let _ = try_log(&self.config, record, &mut stderr_lock);
+                    let _ = try_log_mutex(&self.config, record, &mut stderr_lock);
                 }
                 _ => {
                     let stdout = stdout();
                     let mut stdout_lock = stdout.lock();
-                    let _ = try_log(&self.config, record, &mut stdout_lock);
+                    let _ = try_log_mutex(&self.config, record, &mut stdout_lock);
                 }
             }
         }

--- a/src/loggers/buffer.rs
+++ b/src/loggers/buffer.rs
@@ -60,7 +60,7 @@ impl<W: Write> ThreadWriter<W> {
 
     // Buffer some data, if full then the value is returned as an error
     pub fn add(&self, buf: Vec<u8>) -> Result<(), Error> {
-        if self.buf.len() == 99 {
+        if self.buf.len() >= 99 {
             self.flush_buf().expect("Flush error: ");
         }
         Ok(self.buf.push(buf).expect("ArrayQueue push filed: "))

--- a/src/loggers/buffer.rs
+++ b/src/loggers/buffer.rs
@@ -1,0 +1,68 @@
+use crossbeam::queue::ArrayQueue;
+use std::io;
+use std::io::{Error, Write};
+use std::sync::Mutex;
+
+pub struct ThreadWriter<W: Write> {
+    inner: Mutex<Option<W>>,
+    // buf: Vec<u8>,
+    buf: ArrayQueue<Vec<u8>>,
+}
+
+impl<W: Write> ThreadWriter<W> {
+    pub fn new(inner: W) -> ThreadWriter<W> {
+        ThreadWriter::with_capacity(100, inner)
+    }
+
+    pub fn with_capacity(capacity: usize, inner: W) -> ThreadWriter<W> {
+        ThreadWriter {
+            inner: Mutex::new(Some(inner)),
+            buf: ArrayQueue::<Vec<u8>>::new(capacity),
+        }
+    }
+
+    pub fn flush_buf(&self) -> io::Result<()> {
+        let mut counter = self.buf.capacity();
+
+        // @TODO need to find a good capacity..
+        // so we don't reallocate to often
+        let mut logs = Vec::<u8>::with_capacity(1024 * 8);
+        while !self.buf.is_empty() || counter == 0 {
+            match self.buf.pop() {
+                Some(mut log) => logs.append(&mut log),
+                None => break,
+            }
+            counter -= 1;
+        }
+//        println!("{}", std::str::from_utf8(&logs).unwrap());
+
+        let wrt = self
+            .inner
+            .lock()
+            .expect("mutex posioned")
+            .as_mut()
+            .unwrap()
+            .write_all(&logs);
+
+        // Currently we don't recover the removed buffer if
+        // an error happens.
+        match wrt {
+//          Ok(0) => {
+//                return Err(Error::new(
+//                    ErrorKind::WriteZero,
+//                    "failed to write the buffered data",
+//                ));
+//            }
+            Ok(_) => Ok(()),
+            Err(e) => return Err(e),
+        }
+    }
+
+    // Buffer some data, if full then the value is returned as an error
+    pub fn add(&self, buf: Vec<u8>) -> Result<(), Error> {
+        if self.buf.len() >= 40 {
+            self.flush_buf().expect("Flush error: ");
+        }
+        Ok(self.buf.push(buf).expect("ArrayQueue push filed: "))
+    }
+}

--- a/src/loggers/buffer.rs
+++ b/src/loggers/buffer.rs
@@ -1,4 +1,4 @@
-use crossbeam::queue::ArrayQueue;
+use crossbeam_queue::ArrayQueue;
 use std::io;
 use std::io::{Error, Write};
 use std::sync::Mutex;
@@ -60,7 +60,7 @@ impl<W: Write> ThreadWriter<W> {
 
     // Buffer some data, if full then the value is returned as an error
     pub fn add(&self, buf: Vec<u8>) -> Result<(), Error> {
-        if self.buf.len() >= 40 {
+        if self.buf.len() == 99 {
             self.flush_buf().expect("Flush error: ");
         }
         Ok(self.buf.push(buf).expect("ArrayQueue push filed: "))

--- a/src/loggers/mod.rs
+++ b/src/loggers/mod.rs
@@ -6,6 +6,7 @@ mod termlog;
 #[cfg(feature = "test")]
 mod testlog;
 mod writelog;
+mod buffer;
 
 pub use self::comblog::CombinedLogger;
 pub use self::baselog::SimpleLogger;

--- a/src/loggers/termlog.rs
+++ b/src/loggers/termlog.rs
@@ -24,19 +24,11 @@ pub enum TermLogError {
 
 impl fmt::Display for TermLogError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use std::error::Error as FmtError;
-
-        write!(f, "{}", self.description())
+        write!(f, "{}", self.to_string())
     }
 }
 
 impl error::Error for TermLogError {
-    fn description(&self) -> &str {
-        match *self {
-            SetLogger(ref err) => err.description(),
-        }
-    }
-
     fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             SetLogger(ref err) => Some(err),


### PR DESCRIPTION
Still an early draft and wanted to get your opinion on it. 
### Summary
I used [Crossbeam's ArrayQueue](https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-queue) to create a multi-threaded buffer. This allows any thread to write log messages into the buffer without having to acquire mutex locks.

When the `ArrayQueue` is full the current thread that would overfill:
1. Gets a lock to the underlying `Writer`
2. Drains the queue
3. writes to the file using the os i/o

While this is happening other threads can still continue to do work and write to the buffer. In the case that logs are being written to the buffer faster than it can be drained then those threads would attempt to acquire the lock for the file i/o and wait. I don't think this should be happening often though.

### Comparison Overview
| Old (Mutex) 	| New (ArrayQueue) 	|
|-	|-	|
| New log!<br> 1 Acquire mutex lock<br> 2 check level (warn, err..)<br> 3 construct msg based on config<br> 4 write msg to underlying <Write><br> 5 free lock 	| New log!<br> 1 check level<br> 2 construct msg<br> 3 write msg to ArrayQueue<br> 4. If queue is full this thread gets a<br> mutex lock, drains the queue, writes<br> to file. Other threads can still write<br> during this time.  	|

With the normal simple log there can be lock contention when multiple threads want to write a log entry at the same time. In addition, it is locked not just when writing the log message to the `Writer` but also while the log message is being constructed.

With the new version there is no need to acquire a lock when writing a log entry. When the `ArrayQueue` is close to being full it gets drained by whatever thread puts it over it's limit. While this is happening other threads can still write without waiting.

### Benchmarks
I added some simple benchmarks using [criterion](https://github.com/bheisler/criterion.rs). There are three benchmarks:
1. arrayqueue: The new arrayqueue based log
2. simple: simple log writing to file (like in the example)
3. simplebuf: same as simple but using a BufWriter around the file.

The benchmark spawns threads and on each thread just loops sending a simple log message including the thread# and msg#.

### Running the benchmarks yourself
In the `benches` folder at the top of each file there is `const NTHREADS: u32 = 4;`. Right now you have to manually set this in each file to the number threads you want to spawn.

After that is set from the root run:
``` Bash
mkdir log
cargo bench
```
`log` is where the files from the bench get written to.

Right now the logs aren't automatically cleared so don't forget to clear the log folder each time before running `bench`. 

### Things still need to do

- [ ] Flush the current buffer if there's an error
- [ ] Find a good size for the buffers. Right now I just randomly picked some numbers
- [ ] Do some profiling

Resolve #1